### PR TITLE
Use LED_CAPS_LOCK flag instead of keeping the state internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,3 @@ out [Kaleidoscope-OneShot](https://github.com/keyboardio/Kaleidoscope-OneShot).
 Kaleidoscope-OneShot mimics holding down a specific modifier key by hand (e.g. the shift
 key), and thus it affects the state of every key pressed while the OneShot modifier is
 active.
-
-## Known Issues:
-
-There seems to be an issue with the LED_CAPS_LOCK state tracked by the keyboard (the
-observed behavior is that LED_CAPS_LOCK gets turned on the first time Key_CapsLock is
-pressed, and then is not turned off on subsequent presses). As a result, after 
-initialization Kaleidoscope-CapsLock tracks its own state. There's a small possibility
-this will result in inconsistent state, where the OS thinks Caps Lock is off but the
-keyboard LEDs will indicate that it's on. Unplug the keyboard and plug it back in to
-resolve this if it happens to you.

--- a/src/Kaleidoscope-CapsLock.cpp
+++ b/src/Kaleidoscope-CapsLock.cpp
@@ -2,13 +2,10 @@
 
 namespace kaleidoscope {
 bool CapsLock_::capsCleanupDone = true;
-bool CapsLock_::capsState = false;
 cRGB activeModeColor = CRGB(255, 0, 0);
 
 void CapsLock_::begin(void) {
-  capsState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_CAPS_LOCK);
   Kaleidoscope.useLoopHook(capsLockLoopHook);
-  Kaleidoscope.useEventHandlerHook(capsLockEventHandlerHook);
 }
 
 /*
@@ -18,6 +15,8 @@ void CapsLock_::begin(void) {
 void CapsLock_::capsLockLoopHook(bool postClear) {
   if (!postClear)
     return;
+
+  bool capsState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_CAPS_LOCK);
 
   if (capsState) {
     capsCleanupDone = false;
@@ -46,21 +45,6 @@ void CapsLock_::capsLockLoopHook(bool postClear) {
   }
 }
 
-/*
-  eventHandlerHook listens for "presses" of the mapped CapsLock key.
-  When that key is toggled on, flip the capsState bit.
-*/
-Key CapsLock_::capsLockEventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
-  if ((key_state & INJECTED) || !keyToggledOn(key_state))
-    return mapped_key;
-  
-  if (mapped_key == Key_CapsLock) {
-      // LED_CAPS_LOCK isn't ever toggled off after being set. Track state ourselves.
-      capsState = !capsState;
-  }
-  
-  return mapped_key;
-}
 }
 
 kaleidoscope::CapsLock_ CapsLock;

--- a/src/Kaleidoscope-CapsLock.h
+++ b/src/Kaleidoscope-CapsLock.h
@@ -12,10 +12,8 @@ class CapsLock_ : public KaleidoscopePlugin {
 
  private:
   static void capsLockLoopHook(const bool postClear);
-  static Key  capsLockEventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state); 
 
   static bool capsCleanupDone;
-  static bool capsState;
 };
 }
 


### PR DESCRIPTION
Unlike what the README used to describe as a "known issue", using the LED state flag works perfectly fine (at least on my system) and avoids getting out of sync when capslock is pressed on another keyboard, for example.

I suppose this has been fixed in Kaleidoscope since this plugin was originally written, but in any case, with these changes the plugin works perfectly on my system (Lenovo T430s, Manjaro linux), so it would be nice if you could test it again with the latest Kaleidoscope/Model01 firmware and confirm.