### PR TITLE
Remove deprecated LEDUtils.h include

### DIFF
--- a/src/Kaleidoscope-CapsLock.cpp
+++ b/src/Kaleidoscope-CapsLock.cpp
@@ -1,5 +1,4 @@
 #include "Kaleidoscope-CapsLock.h"
-#include "LEDUtils.h"
 #include "Kaleidoscope.h"
 
 bool CapsLock_::capsCleanupDone = true;
@@ -54,7 +53,7 @@ kaleidoscope::EventHandlerResult CapsLock_::onKeyswitchEvent(
   */
   if (mappedKey == Key_CapsLock) {
     if (keyToggledOff(keyState) ) {
-      /*        
+      /*
         The keyToggledOff keyState indicates that the key was released in the last cycle.
         Use that keyState value as a trigger to toggle software state.
       */

--- a/src/Kaleidoscope-CapsLock.h
+++ b/src/Kaleidoscope-CapsLock.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Kaleidoscope-LEDControl.h"
-#include "LEDUtils.h"
 
 class CapsLock_ : public kaleidoscope::Plugin {
   public:


### PR DESCRIPTION
LEDUtils.h was removed in https://github.com/keyboardio/Kaleidoscope/pull/531